### PR TITLE
Allow configuration of a cache for the RSSClientBundle

### DIFF
--- a/src/Desarrolla2/RSSClient/RSSCacheClient.php
+++ b/src/Desarrolla2/RSSClient/RSSCacheClient.php
@@ -72,6 +72,16 @@ class RSSCacheClient extends RSSClient
     }
 
     /**
+     * Set cache
+     *
+     * @param \Desarrolla2\Cache\CacheInterface $cache
+     */
+    public function setCache(CacheInterface $cache = null)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
      * Generate a unique hash for Cache
      * 
      * @param string $channel


### PR DESCRIPTION
Implement a setCache function.
This is part of a changeset to allow the configuration of a cache by configuration for the RSSClientBundle.
