### PR TITLE
Default value for CacheInterface in cunstructor

### DIFF
--- a/src/Desarrolla2/RSSClient/RSSCacheClient.php
+++ b/src/Desarrolla2/RSSClient/RSSCacheClient.php
@@ -50,7 +50,7 @@ class RSSCacheClient extends RSSClient
      * @param array $feeds
      * @param string $channel
      */
-    public function __construct(CacheInterface $cache, $feeds = array(), $channel = 'default')
+    public function __construct(CacheInterface $cache = null, $feeds = array(), $channel = 'default')
     {
         $this->cache = $cache;
         parent::__construct($feeds, $channel);


### PR DESCRIPTION
This is part of a changeset to allow the configuration of a cache by configuration for the RSSClientBundle.
Sorry I have forgotten to submit this pull request. Without the default value for CacheInterface in the class constructor it won´t work!
