### PR TITLE
Fix validate item node

### DIFF
--- a/src/Desarrolla2/RSSClient/Factory/Atom10NodeFactory.php
+++ b/src/Desarrolla2/RSSClient/Factory/Atom10NodeFactory.php
@@ -36,14 +36,12 @@ class Atom10NodeFactory extends AbstractNodeFactory
     public function create(DOMElement $entry)
     {
         $node = $this->getNode();
+        $node->validate($entry);
+
         $this->setProperties($entry, $node);
         $this->setCategories($entry, $node);
         $this->setLink($entry, $node);
         $this->setPubDate($entry, $node);
-
-        if (!$node->getGuid()) {
-            throw new ParseException('Guid not found');
-        }
 
         return $node;
     }

--- a/src/Desarrolla2/RSSClient/Factory/RSS20NodeFactory.php
+++ b/src/Desarrolla2/RSSClient/Factory/RSS20NodeFactory.php
@@ -42,10 +42,6 @@ class RSS20NodeFactory extends AbstractNodeFactory
         $this->setCategories($item, $node);
         $this->setPubDate($item, $node);
 
-        if (!$node->getGuid()) {
-            throw new ParseException('Guid not found');
-        }
-
         return $node;
     }
 

--- a/src/Desarrolla2/RSSClient/Factory/RSS20NodeFactory.php
+++ b/src/Desarrolla2/RSSClient/Factory/RSS20NodeFactory.php
@@ -36,6 +36,7 @@ class RSS20NodeFactory extends AbstractNodeFactory
     public function create(DOMElement $item)
     {
         $node = $this->getNode();
+        $node->validate($item);
 
         $this->setProperties($item, $node);
         $this->setLink($item, $node);
@@ -101,5 +102,4 @@ class RSS20NodeFactory extends AbstractNodeFactory
     {
         return new RSS20();
     }
-
 }

--- a/src/Desarrolla2/RSSClient/Node/Atom10.php
+++ b/src/Desarrolla2/RSSClient/Node/Atom10.php
@@ -13,6 +13,8 @@
 namespace Desarrolla2\RSSClient\Node;
 
 use Desarrolla2\RSSClient\Node\Node;
+use Desarrolla2\RSSClient\Exception\ParseException;
+use \DOMElement;
 
 /**
  *
@@ -24,4 +26,27 @@ use Desarrolla2\RSSClient\Node\Node;
  */
 class Atom10 extends Node
 {
+    /**
+     * Based Atom 1.0 specification
+     *
+     * @link http://www.atomenabled.org/developers/syndication/atom-format-spec.php#element.entry
+     */
+    public function validate(DOMElement $entry){
+        //@TODO: define all properties
+        $properties = array(
+            'id'          	=> array('required' => TRUE),
+            'title'         => array('required' => TRUE), 
+            'content'   	=> array('required' => TRUE),
+            'updated'		=> array('required' => TRUE),
+            'link'			=> array('required' => FALSE),
+        );
+        foreach ($properties as $propertyName => $attributes) {
+            if($attributes['required'] == FALSE) continue;
+
+            $value = $entry->getElementsByTagName($propertyName)->item(0);
+            if(!$value){
+                throw new ParseException('<entry> node invalid');
+            }
+        }
+    }
 }

--- a/src/Desarrolla2/RSSClient/Node/RSS20.php
+++ b/src/Desarrolla2/RSSClient/Node/RSS20.php
@@ -13,6 +13,8 @@
 namespace Desarrolla2\RSSClient\Node;
 
 use Desarrolla2\RSSClient\Node\Node;
+use Desarrolla2\RSSClient\Exception\ParseException;
+use \DOMElement;
 
 /**
  *
@@ -24,4 +26,32 @@ use Desarrolla2\RSSClient\Node\Node;
  */
 class RSS20 extends Node
 {
+    /**
+     * Based RSS2.0 specification
+     *
+     * @link http://feed2.w3.org/docs/rss2.html#requiredChannelElements
+     * @return boolean
+     */
+    public function validate(DOMElement $item){
+        $properties = array(
+            'title'         => array('required' => TRUE), 
+            'link'          => array('required' => TRUE),
+            'description'   => array('required' => TRUE),
+            'author'        => array('required' => FALSE), 
+            'category'      => array('required' => FALSE), 
+            'comments'      => array('required' => FALSE), 
+            'enclosure'     => array('required' => FALSE),
+            'guid'          => array('required' => FALSE),
+            'pubDate'       => array('required' => FALSE), 
+            'source'        => array('required' => FALSE), 
+        );
+        foreach ($properties as $propertyName => $attributes) {
+            if($attributes['required'] == FALSE) continue;
+
+            $value = $item->getElementsByTagName($propertyName)->item(0);
+            if(!$value){
+                throw new ParseException('<item> node invalid');
+            }
+        }
+    }
 }

--- a/src/Desarrolla2/RSSClient/Node/RSS20.php
+++ b/src/Desarrolla2/RSSClient/Node/RSS20.php
@@ -30,7 +30,6 @@ class RSS20 extends Node
      * Based RSS2.0 specification
      *
      * @link http://feed2.w3.org/docs/rss2.html#requiredChannelElements
-     * @return boolean
      */
     public function validate(DOMElement $item){
         $properties = array(


### PR DESCRIPTION
Implemented validator for item and entry nodes. In RSS2.0Node, for example, <guid> is an optional (and not required) sub-element of <item>
