### PR TITLE
Support on Guzzle lastest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "3.0.*",
+        "guzzle/guzzle": "3.*",
         "ezyang/htmlpurifier": "4.5.*",
         "desarrolla2/cache": "1.*"
     },


### PR DESCRIPTION
Can we change package requirement to be guzzle 3.x ? Passed the PHPUnit test.
Currently last version is 3.7.
