### PR TITLE
Use prefer source to prevent travis build filed due to Api Call limitati...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ notifications:
     - daniel.gonzalez@freelancemadrid.es
 
 before_script:
-  - composer install
+  - composer install --prefer-source


### PR DESCRIPTION
Travis should use -prefer-source for the composer to avoid build failed from Github API call limitation and Tarball.
