### PR TITLE
a fix not to stop parsing on lack of pubdate on nodes

### DIFF
--- a/src/Desarrolla2/RSSClient/Node/NodeCollection.php
+++ b/src/Desarrolla2/RSSClient/Node/NodeCollection.php
@@ -64,6 +64,8 @@ class NodeCollection extends \ArrayObject
         $total = $this->count();
         for ($i = 1; $i < $total; $i++) {
             for ($j = 0; $j < $total - $i; $j++) {
+                if ($this[$j]->getPubDate() === NULL
+                    || $this[$j+1]->getPubDate() === NULL) { continue; }
                 if ($this[$j]->getPubDate()->getTimestamp() > $this[$j + 1]->getPubDate()->getTimestamp()) {
                     continue;
                 }

--- a/tests/Desarrolla2/RSSClient/Node/Test/NodeCollectionTest.php
+++ b/tests/Desarrolla2/RSSClient/Node/Test/NodeCollectionTest.php
@@ -59,6 +59,32 @@ class NodeCollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test if any or all node do not have PubDate
+     */
+    public function testShortLackOfPubdate()
+    {
+        $dates = array(
+            '2012-01-01',
+            '2012-01-02',
+            '2012-01-03',
+        );
+
+        foreach ($dates as $date) {
+            $node = new Node();
+            if ($date !== '2012-01-02') {
+                // intentinally make a node without pubdate
+                $node->setPubDate(new \DateTime($date));
+            }
+            $this->collection->append($node);
+        }
+
+        $this->collection->short();
+        $first = $this->collection->getFirst();
+        // bubble sort won't happen
+        $this->assertEquals($first->getPubDate()->format('d'), '1');
+    }
+
+    /**
      * @dataProvider dataProviderForTestLimit
      */
     public function testLimit($limit)


### PR DESCRIPTION
I had a fatal error when let RSSClient parse Hacker News rss feed. Though that feed seems badly designed, I think it does not need to stop itself so added a code to ignore the error.

I also had an idea to let it throw some kind of "parse failed exceptions" for library users who really want to know if the date sort failed, but it might not be a big issue for normal use.
