### PR TITLE
Store the extended RSS information in the node

### DIFF
--- a/src/Desarrolla2/RSSClient/Factory/RSS20NodeFactory.php
+++ b/src/Desarrolla2/RSSClient/Factory/RSS20NodeFactory.php
@@ -77,11 +77,11 @@ class RSS20NodeFactory extends AbstractNodeFactory
         $values = array();
         $list = $item->getElementsByTagName('*');
         for ($i = 0; $i < $list->length; $i++) {
-          /* @var $result \DOMNode */
-          $result = $list->item($i);
-          if ($result->nodeValue) {
-            $values[$result->nodeName] = $result->nodeValue;
-          }
+            /* @var $result \DOMNode */
+            $result = $list->item($i);
+            if ($result->nodeValue) {
+                $values[$result->nodeName] = $result->nodeValue;
+            }
         }
         return $values;
     }

--- a/src/Desarrolla2/RSSClient/Factory/RSS20NodeFactory.php
+++ b/src/Desarrolla2/RSSClient/Factory/RSS20NodeFactory.php
@@ -56,15 +56,34 @@ class RSS20NodeFactory extends AbstractNodeFactory
             'guid',
             'source'
         );
+        $values = $this->createValuesList($item);
         foreach ($properties as $propertyName) {
-            $value = $this->getNodeValueByTagName($item, $propertyName);
-            if ($value) {
+            if (isset($values[$propertyName])) {
                 $method = 'set' . $propertyName;
                 $node->$method(
-                    $this->doClean($value)
+                    $this->doClean($values[$propertyName])
                 );
+                unset($values[$propertyName]);
             }
         }
+        foreach ($values as $key => $value) {
+            /* @var $item \DomElement */
+            $node->setExtended($key, $this->doClean($value));
+        }
+    }
+
+    private function createValuesList(\DOMElement $item)
+    {
+        $values = array();
+        $list = $item->getElementsByTagName('*');
+        for ($i = 0; $i < $list->length; $i++) {
+          /* @var $result \DOMNode */
+          $result = $list->item($i);
+          if ($result->nodeValue) {
+            $values[$result->nodeName] = $result->nodeValue;
+          }
+        }
+        return $values;
     }
 
     /**

--- a/tests/Desarrolla2/RSSClient/Factory/Test/RSS20NodeFactoryTest.php
+++ b/tests/Desarrolla2/RSSClient/Factory/Test/RSS20NodeFactoryTest.php
@@ -126,8 +126,8 @@ class RSS20NodeFactoryTest extends AbstractNodeFactoryTest
         $description,
         $pubDay,
         $totalCategories,
-        array $extended = array())
-    {
+        array $extended = array()
+    ) {
         parent::testNodeFactory($file, $title, $guid, $link, $description, $pubDay, $totalCategories);
         $this->assertInstanceOf('Desarrolla2\RSSClient\Node\RSS20', $this->node);
         $this->assertNull($this->node->getExtended('author'));

--- a/tests/Desarrolla2/RSSClient/Factory/Test/RSS20NodeFactoryTest.php
+++ b/tests/Desarrolla2/RSSClient/Factory/Test/RSS20NodeFactoryTest.php
@@ -103,6 +103,7 @@ class RSS20NodeFactoryTest extends AbstractNodeFactoryTest
                 'En el primer artículo de la serie ...',
                 '19',
                 6,
+                array('thr:total' => 2)
             ),
         );
     }
@@ -117,8 +118,13 @@ class RSS20NodeFactoryTest extends AbstractNodeFactoryTest
      * @param string $pubDay
      * @param int    $totalCategories
      */
-    public function testNodeFactory($file, $title, $guid, $link, $description, $pubDay, $totalCategories)
+    public function testNodeFactory($file, $title, $guid, $link, $description, $pubDay, $totalCategories, array $extended = array())
     {
         parent::testNodeFactory($file, $title, $guid, $link, $description, $pubDay, $totalCategories);
+        $this->assertInstanceOf('Desarrolla2\RSSClient\Node\RSS20', $this->node);
+        $this->assertNull($this->node->getExtended('author'));
+        foreach ($extended as $key => $expected) {
+            $this->assertEquals($expected, $this->node->getExtended($key));
+        }
     }
 }

--- a/tests/Desarrolla2/RSSClient/Factory/Test/RSS20NodeFactoryTest.php
+++ b/tests/Desarrolla2/RSSClient/Factory/Test/RSS20NodeFactoryTest.php
@@ -118,7 +118,15 @@ class RSS20NodeFactoryTest extends AbstractNodeFactoryTest
      * @param string $pubDay
      * @param int    $totalCategories
      */
-    public function testNodeFactory($file, $title, $guid, $link, $description, $pubDay, $totalCategories, array $extended = array())
+    public function testNodeFactory(
+        $file,
+        $title,
+        $guid,
+        $link,
+        $description,
+        $pubDay,
+        $totalCategories,
+        array $extended = array())
     {
         parent::testNodeFactory($file, $title, $guid, $link, $description, $pubDay, $totalCategories);
         $this->assertInstanceOf('Desarrolla2\RSSClient\Node\RSS20', $this->node);


### PR DESCRIPTION
Currently unknown nodes are discarded for RSS 2.0 feeds. For one of my projects I need to access that node, but I found out that it was discarded in the RSS20NodeFactory.

This would allow me to fetch that node, for instance the "thr:total" node through the extended properties of the node.
